### PR TITLE
Distil upgrade patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
-FROM alpine:3.3
+FROM node
 
-MAINTAINER Roman Tarnavski
+RUN mkdir app
 
-RUN apk add --update nginx
+WORKDIR app
 
-COPY nginx.conf /etc/nginx/
-ADD ./dist/ /usr/share/nginx/html
+COPY . ./
+
+RUN npm install
+
+RUN npm run build
 
 EXPOSE 8080
 
-CMD nginx -g 'daemon off;'
+CMD npm run serve

--- a/src/main/javascript/SwaggerUi.js
+++ b/src/main/javascript/SwaggerUi.js
@@ -147,12 +147,16 @@ window.SwaggerUi = Backbone.Router.extend({
       swaggerOptions: this.options,
       router: this
     }).render();
-    this.apiSearchView = new SwaggerUi.Views.ApiSearchView({
-      model: this.api,
-      el: $(this.api_search_id),
-      swaggerOptions: this.options,
-      router: this
-    }).render();
+
+    if (!this.options.hideApiSearch) {
+      this.apiSearchView = new SwaggerUi.Views.ApiSearchView({
+        model: this.api,
+        el: $(this.api_search_id),
+        swaggerOptions: this.options,
+        router: this
+      }).render();
+    }
+
     if (!_.isEmpty(this.api.securityDefinitions)){
       authsModel = _.map(this.api.securityDefinitions, function (auth, name) {
         var result = {};

--- a/src/main/less/distil.less
+++ b/src/main/less/distil.less
@@ -1,5 +1,5 @@
 .distil-logo {
-  min-width: 121px;
+  min-width: 135px;
   text-indent: -9999px;
   background: transparent url(../images/distil-logo.png) no-repeat left center;
 }


### PR DESCRIPTION
## Overview
PR to capture changes made within Prism to the swagger UI bundle.

Both changes are tied to a new API docs page added for the partner-focused integration. To start with we're reusing the existing API docs structure with a few tweaks. There are multiple APIs being exposed on different hosts so we need to customize the page to serve multiple API definitions. 

Unfortunately swagger-ui 2.x breaks if you create multiple instances of the UI on the same page due to dependencies on some specially named window-level globals. As a workaround for now the new page will have a nav menu where you can select the API you wish to see. However that also breaks the search bar. I _could_ dig into the old version of Backbone this uses and try to figure out how to make it properly unbind and rebind the swagger model but for now it's quicker to just disable the search on that page given the small number of APIs involved.

I also looked at swagger UI 3.x but that's a complete standalone Node.js app. This is a quick fix to get our small story out and I'm capturing the change in this repo to keep it in sync with Prism. Ultimately I'll need to rethink the API doc management if we're going to build out additional services like `plt_bon`, `bon_creds`, and others. That will probably result in a standalone version of the docs, using doc support in an API gateway solution, or leveraging a third party like SwaggerHub.

### Changes
* Ability to disable the API search view via an option
* Extend the width of the logo style so a custom nav fits better on a new API docs page
* Updated the Dockerfile so I could actually run the build locally (the old Dockerfile assumes you build locally)

